### PR TITLE
Make decompme happy with our rep stosd

### DIFF
--- a/src/bin/satsuki.rs
+++ b/src/bin/satsuki.rs
@@ -173,6 +173,7 @@ fn handle_disassemble(
                 .disassemble(
                     &capstone,
                     &executable,
+                    !args.att,
                     args.force_address_zero,
                     args.resolve_names,
                 )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,6 +374,7 @@ impl Function {
         &self,
         ctx: &Capstone,
         executable: &Executable,
+        intel_syntax: bool,
         force_address_zero: bool,
         resolve_names: bool,
         labels: &HashMap<u64, String>,
@@ -451,7 +452,7 @@ impl Function {
             }
         }
 
-        if !has_custom_format && is_rep && is_stosd {
+        if !has_custom_format && intel_syntax && is_rep && is_stosd {
             // The default formatter will write this as `rep stosd dword ptr es:[edi], eax`, which
             // decompme does not like.
             writeln!(res, "    rep stosd")?;
@@ -476,6 +477,7 @@ impl Function {
         &self,
         ctx: &Capstone,
         executable: &Executable,
+        intel_syntax: bool,
         force_address_zero: bool,
         resolve_names: bool,
     ) -> Result<String, ExecutableError> {
@@ -501,6 +503,7 @@ impl Function {
             res.push_str(&self.format_instruction(
                 ctx,
                 executable,
+                intel_syntax,
                 force_address_zero,
                 resolve_names,
                 &labels,


### PR DESCRIPTION
Decomp.me only accepts `rep stosd`, and not the long form `rep stosd dword ptr es:[edi], eax`. So we fix satsuki to emit only the second.