### PR TITLE
Allow CSV rows to have different sizes

### DIFF
--- a/src/bin/satsuki.rs
+++ b/src/bin/satsuki.rs
@@ -303,6 +303,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mapping = if is_csv {
         let mut rdr = csv::ReaderBuilder::new()
             .has_headers(false)
+            .flexible(true)
             .from_reader(raw_mapping.as_bytes());
         Mapping {
             function: Some(Result::from_iter(rdr.deserialize())?)


### PR DESCRIPTION
This will be useful to include the argument types to the CSV.